### PR TITLE
fix: Resuelto errores encontrados por los usuarios sobre eventos

### DIFF
--- a/backend/src/main/java/es/us/meerkat/backend/controller/CommunityController.java
+++ b/backend/src/main/java/es/us/meerkat/backend/controller/CommunityController.java
@@ -847,7 +847,8 @@ public class CommunityController {
     })
     public ResponseEntity<List<EventSummaryResponse>> listCommunityEvents(
             @PathVariable Long communityId,
-            @RequestParam(name = "cancelados", defaultValue = "false") boolean cancelados) {
+            @RequestParam(name = "cancelados", defaultValue = "false") boolean cancelados,
+            @AuthenticationPrincipal Usuario usuario) {
 
         try {
             communityService.getCommunityById(communityId, null);
@@ -855,7 +856,8 @@ public class CommunityController {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
         }
 
-        List<Evento> eventos = eventoService.obtenerEventosPorComunidad(communityId, cancelados);
+        Long usuarioId = usuario != null ? usuario.getId() : null;
+        List<Evento> eventos = eventoService.obtenerEventosPorComunidad(communityId, cancelados, usuarioId);
         List<EventSummaryResponse> response =
                 eventos.stream().map(Evento::toSummaryDTO).collect(Collectors.toList());
 

--- a/backend/src/main/java/es/us/meerkat/backend/controller/EventoController.java
+++ b/backend/src/main/java/es/us/meerkat/backend/controller/EventoController.java
@@ -90,6 +90,7 @@ public class EventoController {
      * Obtiene un evento por su ID.
      *
      * @param eventId Identificador del evento.
+     * @param usuario Usuario autenticado (puede ser null).
      * @return El evento encontrado.
      */
     @GetMapping("/{eventId}")
@@ -97,8 +98,10 @@ public class EventoController {
             summary = "Obtener evento por ID",
             description = "Devuelve los detalles completos de un evento")
     public ResponseEntity<EventDetailResponse> obtenerEvento(
-            @PathVariable @Parameter(description = "ID del evento") final Long eventId) {
-        return ResponseEntity.ok(eventoService.obtenerEvento(eventId).toDTO());
+            @PathVariable @Parameter(description = "ID del evento") final Long eventId,
+            @AuthenticationPrincipal Usuario usuario) {
+        Long usuarioId = usuario != null ? usuario.getId() : null;
+        return ResponseEntity.ok(eventoService.obtenerEvento(eventId, usuarioId).toDTO());
     }
 
     /**
@@ -189,7 +192,7 @@ public class EventoController {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Usuario no autenticado");
         }
 
-        final Evento evento = eventoService.obtenerEvento(eventId);
+        final Evento evento = eventoService.obtenerEventoInterno(eventId);
         if (!evento.getCreador().getId().equals(usuario.getId())) {
             throw new ResponseStatusException(
                     HttpStatus.FORBIDDEN, "Solo el creador del evento puede editarlo");
@@ -235,7 +238,7 @@ public class EventoController {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Usuario no autenticado");
         }
 
-        final Evento evento = eventoService.obtenerEvento(eventId);
+        final Evento evento = eventoService.obtenerEventoInterno(eventId);
         if (!evento.getCreador().getId().equals(usuario.getId())) {
             throw new ResponseStatusException(
                     HttpStatus.FORBIDDEN, "Solo el creador del evento puede cancelarlo");

--- a/backend/src/main/java/es/us/meerkat/backend/repository/EventoRepository.java
+++ b/backend/src/main/java/es/us/meerkat/backend/repository/EventoRepository.java
@@ -28,7 +28,7 @@ public interface EventoRepository extends JpaRepository<Evento, Long> {
      *
      * @return Lista de eventos visibles en mapa.
      */
-    @Query("SELECT e FROM Evento e WHERE e.visibleMapa = true AND e.cancelado = false")
+    @Query("SELECT e FROM Evento e WHERE e.visibleMapa = true AND e.cancelado = false AND e.privado = false")
     List<Evento> findVisibleOnMap();
 
     /**

--- a/backend/src/main/java/es/us/meerkat/backend/service/EventoService.java
+++ b/backend/src/main/java/es/us/meerkat/backend/service/EventoService.java
@@ -17,6 +17,8 @@ import es.us.meerkat.backend.repository.UbicacionRepository;
 import es.us.meerkat.backend.repository.UsuarioRepository;
 import lombok.RequiredArgsConstructor;
 
+import java.util.stream.Collectors;
+
 /**
  * Servicio para gestionar la lógica de negocio relacionada con los eventos.
  *
@@ -40,6 +42,9 @@ public class EventoService {
 
     /** Repositorio para acceder a la información de ubicaciones. */
     private final UbicacionRepository ubicacionRepository;
+
+    /** Servicio de autorización para verificar roles en comunidades. */
+    private final AuthorizationService authorizationService;
 
     // ===============================
     // CREAR EVENTO
@@ -225,12 +230,33 @@ public class EventoService {
     // ===============================
 
     /**
-     * Obtiene un evento por su ID.
+     * Obtiene un evento por su ID, verificando permisos de visibilidad.
+     *
+     * @param eventoIdParam Identificador del evento.
+     * @param usuarioId Identificador del usuario que solicita (puede ser null).
+     * @return El evento encontrado.
+     */
+    public Evento obtenerEvento(final Long eventoIdParam, final Long usuarioId) {
+        final Evento evento = eventoRepository
+                .findById(eventoIdParam)
+                .orElseThrow(() -> new RuntimeException("Evento no encontrado"));
+
+        if (Boolean.TRUE.equals(evento.getPrivado())) {
+            if (!puedeVerEventoPrivado(evento, usuarioId)) {
+                throw new RuntimeException("No tienes permiso para ver este evento privado");
+            }
+        }
+
+        return evento;
+    }
+
+    /**
+     * Obtiene un evento por su ID sin verificar visibilidad (uso interno).
      *
      * @param eventoIdParam Identificador del evento.
      * @return El evento encontrado.
      */
-    public Evento obtenerEvento(final Long eventoIdParam) {
+    public Evento obtenerEventoInterno(final Long eventoIdParam) {
         return eventoRepository
                 .findById(eventoIdParam)
                 .orElseThrow(() -> new RuntimeException("Evento no encontrado"));
@@ -285,17 +311,45 @@ public class EventoService {
     // ===============================
 
     /**
-     * Obtiene los eventos de una comunidad.
+     * Obtiene los eventos de una comunidad, filtrando eventos privados según permisos.
      *
      * @param comunidadId Identificador de la comunidad.
      * @param incluirCancelados Si se deben incluir los eventos cancelados.
-     * @return Lista de eventos de la comunidad.
+     * @param usuarioId Identificador del usuario que solicita (puede ser null).
+     * @return Lista de eventos de la comunidad visibles para el usuario.
      */
     public List<Evento> obtenerEventosPorComunidad(
-            final Long comunidadId, final boolean incluirCancelados) {
+            final Long comunidadId, final boolean incluirCancelados, final Long usuarioId) {
+        List<Evento> eventos;
         if (incluirCancelados) {
-            return eventoRepository.findByComunidadId(comunidadId);
+            eventos = eventoRepository.findByComunidadId(comunidadId);
+        } else {
+            eventos = eventoRepository.findByComunidadIdAndCanceladoFalse(comunidadId);
         }
-        return eventoRepository.findByComunidadIdAndCanceladoFalse(comunidadId);
+        return filtrarEventosPrivados(eventos, usuarioId);
+    }
+
+    /**
+     * Verifica si un usuario puede ver un evento privado.
+     * Solo los miembros de la comunidad pueden verlo.
+     */
+    private boolean puedeVerEventoPrivado(final Evento evento, final Long usuarioId) {
+        if (usuarioId == null) {
+            return false;
+        }
+        if (evento.getComunidad() != null) {
+            return authorizationService.isMemberOf(usuarioId, evento.getComunidad().getId());
+        }
+        return false;
+    }
+
+    /**
+     * Filtra una lista de eventos eliminando los privados que el usuario no puede ver.
+     */
+    private List<Evento> filtrarEventosPrivados(final List<Evento> eventos, final Long usuarioId) {
+        return eventos.stream()
+                .filter(evento -> !Boolean.TRUE.equals(evento.getPrivado())
+                        || puedeVerEventoPrivado(evento, usuarioId))
+                .collect(Collectors.toList());
     }
 }

--- a/backend/src/test/java/es/us/meerkat/backend/controller/EventoControllerTest.java
+++ b/backend/src/test/java/es/us/meerkat/backend/controller/EventoControllerTest.java
@@ -85,7 +85,7 @@ class EventoControllerTest {
 
         Evento evento = buildEvento(1L, true);
         evento.setCreador(creador);
-        when(eventoService.obtenerEvento(1L)).thenReturn(evento);
+        when(eventoService.obtenerEventoInterno(1L)).thenReturn(evento);
 
         assertThatThrownBy(
                         () ->

--- a/backend/src/test/java/es/us/meerkat/backend/service/EventoServiceTest.java
+++ b/backend/src/test/java/es/us/meerkat/backend/service/EventoServiceTest.java
@@ -36,6 +36,7 @@ class EventoServiceTest {
     @Mock private ComunidadRepository comunidadRepository;
     @Mock private MiembroComunidadRepository miembroComunidadRepository;
     @Mock private UbicacionRepository ubicacionRepository;
+    @Mock private AuthorizationService authorizationService;
 
     @InjectMocks private EventoService eventoService;
 

--- a/frontend/src/screens/comunidades/CommunityDetail.css
+++ b/frontend/src/screens/comunidades/CommunityDetail.css
@@ -218,6 +218,12 @@
   background-color: #525983;
 }
 
+.cd-member-hint {
+  font-size: 0.85rem;
+  color: #888;
+  font-style: italic;
+}
+
 /* Events list */
 .cd-events-list {
   display: flex;

--- a/frontend/src/screens/comunidades/CommunityDetail.js
+++ b/frontend/src/screens/comunidades/CommunityDetail.js
@@ -150,6 +150,7 @@ export default function CommunityDetail() {
       await communitiesApi.join(communityId);
       setIsMember(true);
       await fetchCommunity(); // Refresh member count
+      await fetchEvents(); // Refresh events to show private events
     } catch (err) {
       console.error('Error al unirse a la comunidad:', err);
       if (err.status === 401 || err.message?.includes('401')) {
@@ -171,6 +172,7 @@ export default function CommunityDetail() {
       await communitiesApi.leave(communityId);
       setIsMember(false);
       await fetchCommunity(); // Refresh member count
+      await fetchEvents(); // Refresh events to hide private events
     } catch (err) {
       console.error('Error al abandonar la comunidad:', err);
       const status = err.status || err.response?.status;
@@ -300,13 +302,15 @@ export default function CommunityDetail() {
                 />
                 Mostrar cancelados
               </label>
-              {isMember && (
+              {isMember ? (
                 <button
                   className="cd-btn cd-btn-create"
                   onClick={() => navigate(`/crear-evento/new?communityId=${communityId}`)}
                 >
                   <LuPlus /> Crear evento
                 </button>
+              ) : (
+                <span className="cd-member-hint">Únete a la comunidad para crear eventos</span>
               )}
             </div>
           </div>
@@ -329,14 +333,18 @@ export default function CommunityDetail() {
             <div className="cd-empty-events">
               <LuCalendar className="cd-empty-icon" />
               <h3>No hay eventos</h3>
-              <p>Sé el primero en crear un evento para esta comunidad.</p>
-              {isMember && (
-                <button
-                  className="cd-btn cd-btn-create"
-                  onClick={() => navigate(`/crear-evento/new?communityId=${communityId}`)}
-                >
-                  <LuPlus /> Crear evento
-                </button>
+              {isMember ? (
+                <>
+                  <p>Sé el primero en crear un evento para esta comunidad.</p>
+                  <button
+                    className="cd-btn cd-btn-create"
+                    onClick={() => navigate(`/crear-evento/new?communityId=${communityId}`)}
+                  >
+                    <LuPlus /> Crear evento
+                  </button>
+                </>
+              ) : (
+                <p>Únete a la comunidad para poder crear eventos.</p>
               )}
             </div>
           )}

--- a/frontend/src/screens/evento/CrearEvento.js
+++ b/frontend/src/screens/evento/CrearEvento.js
@@ -373,7 +373,7 @@ const CrearEvento = () => {
             <div className="input-group">
               <label className="input-label">Materiales necesarios</label>
               <input type="text" name="comentario" placeholder="Ej. Libro de texto, ordenador portátil, calculadora científica" value={formData.comentario} onChange={handleChange} className="input-box input-large" />
-              <span className="field-hint">Indica los materiales que los asistentes deben llevar al evento</span>
+              <span className="field-hint">Separa cada material con una coma (,). Ej: Libro de texto, ordenador portátil, calculadora</span>
             </div>
 
             <div className="input-group">

--- a/frontend/src/screens/evento/DetalleEvento.js
+++ b/frontend/src/screens/evento/DetalleEvento.js
@@ -366,7 +366,7 @@ const DetalleEvento = () => {
                   <LuPackage className="ed-section-icon" /> Materiales necesarios
                 </h2>
                 <div className="ed-materials">
-                  {event.queLlevar.split(',').map((material, index) => (
+                  {event.queLlevar.split(',').filter(m => m.trim() !== '').map((material, index) => (
                     <span key={index} className="ed-material-tag">
                       {material.trim()}
                     </span>


### PR DESCRIPTION
Las modificaciones realizadas han sido:

- A partir de ahora, si no estas unido a la comunidad, sale un texto que dice que no puedes crear un evento a menos de que seas miembro del mismo.

- Dentro de la creación y edición de eventos se puntua que campos son importantes a relllenar, además de poner mensajes de ayuda por si el usuario no sabe porque no le deja crear el evento