### PR TITLE
Feature/#333 corregir footer registro meerkatters

### DIFF
--- a/frontend/src/screens/auth/Register.js
+++ b/frontend/src/screens/auth/Register.js
@@ -195,7 +195,7 @@ const Register = () => {
         </div>
 
         <div className="register-footer">
-          <p>© 2024 StudYshare. All rights reserved.</p>
+          <p>© 2026 Meerkatters. All rights reserved.</p>
         </div>
       </div>
 

--- a/frontend/src/screens/auth/VerifyEmail.js
+++ b/frontend/src/screens/auth/VerifyEmail.js
@@ -215,7 +215,7 @@ const VerifyEmail = () => {
         </div>
 
         <div className="register-footer">
-          <p>© 2024 StudYshare. All rights reserved.</p>
+          <p>© 2026 Meerkatters. All rights reserved.</p>
         </div>
       </div>
 


### PR DESCRIPTION
Qué se cambia
Se corrige el texto del footer en la pantalla de registro.
Antes: “© 2024 StudYshare. All rights reserved.”
Ahora: “© 2026 Meerkatters. All rights reserved.”
Por qué
El nombre de marca en la vista de registro no coincide con la app (Meerkatters), lo que genera inconsistencia de identidad.
Issue relacionada
Closes #333
Tipo de cambio
Bugfix (UI/texto)
Checklist
 Cambio mínimo y acotado al texto del footer
 No afecta lógica de autenticación
 Revisado visualmente en pantalla de registro