### PR TITLE
fix: :bug: pequeña correccion de redireccion al abandonar comunidades

### DIFF
--- a/frontend/src/screens/comunidades/CommunityDetail.js
+++ b/frontend/src/screens/comunidades/CommunityDetail.js
@@ -1038,11 +1038,10 @@ export default function CommunityDetail() {
       setMembershipError(null);
       await communitiesApi.leave(communityId);
       // Si el admin era el único miembro, el backend elimina la comunidad
-      // En ese caso redirigimos a la lista
-      if (isAdmin) {
-        navigate('/comunidades');
-        return;
-      }
+      // Cualquier persona que abandone la comunidad será redirigida a la lista de comunidades
+      
+      navigate('/comunidades');
+      
       setIsMember(false);
       await fetchCommunity(); // Refresh member count
       await fetchEvents(); // Refresh events to hide private events


### PR DESCRIPTION
una vez que abandones una comunidad, seas administrador o no, se redirige a la lista de comunidades